### PR TITLE
修复在python3.x版本下iteritems方法已弃用导致获取签名异常的问题

### DIFF
--- a/qcloud_cos/cos_auth.py
+++ b/qcloud_cos/cos_auth.py
@@ -153,7 +153,7 @@ class CosRtmpAuth(AuthBase):
     def get_rtmp_sign(self):
         # get rtmp string
         canonicalized_param = ''
-        for k, v in self._params.iteritems():
+        for k, v in self._params.items():
             canonicalized_param += '{key}={value}&'.format(key=k, value=v)
         if self._presign_expire >= 60:
             canonicalized_param += 'presign={value}'.format(value=self._presign_expire)


### PR DESCRIPTION
_params为字典，改为items方法即可。