### PR TITLE
fix dump_record_dir operate permission

### DIFF
--- a/qcloud_cos/cos_client.py
+++ b/qcloud_cos/cos_client.py
@@ -3527,7 +3527,7 @@ class CosS3Client(object):
             already_exist_parts[part_num] = part['ETag']
         return True
 
-    def download_file(self, Bucket, Key, DestFilePath, PartSize=20, MAXThread=5, EnableCRC=False, progress_callback=None, **Kwargs):
+    def download_file(self, Bucket, Key, DestFilePath, PartSize=20, MAXThread=5, EnableCRC=False, progress_callback=None, DownloadTmpDir=None, **Kwargs):
         """小于等于20MB的文件简单下载，大于20MB的文件使用续传下载
 
         :param Bucket(string): 存储桶名称.
@@ -3563,7 +3563,7 @@ class CosS3Client(object):
             callback = ProgressCallback(file_size, progress_callback)
 
         downloader = ResumableDownLoader(self, Bucket, Key, DestFilePath, object_info, PartSize, MAXThread, EnableCRC,
-                                         callback, **Kwargs)
+                                         callback, DownloadTmpDir, **Kwargs)
         downloader.start()
 
     def upload_file(self, Bucket, Key, LocalFilePath, PartSize=1, MAXThread=5, EnableMD5=False, progress_callback=None,

--- a/qcloud_cos/resumable_downloader.py
+++ b/qcloud_cos/resumable_downloader.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class ResumableDownLoader(object):
     def __init__(self, cos_client, bucket, key, dest_filename, object_info, part_size=20, max_thread=5,
-                 enable_crc=False, progress_callback=None, **kwargs):
+                 enable_crc=False, progress_callback=None, DownloadTmpDir=None, **kwargs):
         self.__cos_client = cos_client
         self.__bucket = bucket
         self.__key = key
@@ -34,7 +34,10 @@ class ResumableDownLoader(object):
         self.__finished_parts = []
         self.__lock = threading.Lock()
         self.__record = None  # 记录当前的上下文
-        self.__dump_record_dir = os.path.join(os.path.expanduser('~'), '.cos_download_tmp_file')
+
+        if not DownloadTmpDir:
+            DownloadTmpDir = os.path.expanduser('~')
+        self.__dump_record_dir = os.path.join(DownloadTmpDir, '.cos_download_tmp_file')
 
         record_filename = self.__get_record_filename(bucket, key, self.__dest_file_path)
         self.__record_filepath = os.path.join(self.__dump_record_dir, record_filename)


### PR DESCRIPTION
对于容器等场景下，没有当前用户目录权限，对于下载时的临时目录，增加 DownloadTmpDir 参数支持用户自定义