### PR TITLE
修改下载文件默认的cache目录为/tmp下

### DIFF
--- a/qcloud_cos/resumable_downloader.py
+++ b/qcloud_cos/resumable_downloader.py
@@ -34,7 +34,7 @@ class ResumableDownLoader(object):
         self.__finished_parts = []
         self.__lock = threading.Lock()
         self.__record = None  # 记录当前的上下文
-        self.__dump_record_dir = os.path.join(os.path.expanduser('~'), '.cos_download_tmp_file')
+        self.__dump_record_dir = os.path.join('/tmp', '.cos_download_tmp_file')
 
         record_filename = self.__get_record_filename(bucket, key, self.__dest_file_path)
         self.__record_filepath = os.path.join(self.__dump_record_dir, record_filename)


### PR DESCRIPTION
在一些容器部署服务的场景，`os.path.expanduser('~')`会读取到`/root`，但是`/root`下的权限管理比较严格，导致服务部署失败。
这里把cache目录改到`/tmp`下，解决这个问题